### PR TITLE
Open schema validation file in read-only mode

### DIFF
--- a/adaptive_cards/validation.py
+++ b/adaptive_cards/validation.py
@@ -513,7 +513,7 @@ class CardValidator(AbstractCardValidator):
             Path(__file__)
             .parent.joinpath("schemas")
             .joinpath(f"schema-{self.__schema_version}.json"),
-            "+r",
+            "r",
             encoding="utf-8",
         ) as f:  # pylint: disable=C0103
             return json.load(f)


### PR DESCRIPTION
## Description

This PR introduces a small fix in the `CardValidator` class, such that locally stored schema files for validation are opened in **read-only** (`r`) and no longer in **read-and-write** (`+r`) mode. With previous versions, this can lead to issues on read-only systems (see #39).

Closes #39