### PR TITLE
Add ability to @mention users

### DIFF
--- a/src/adaptive_cards/card.py
+++ b/src/adaptive_cards/card.py
@@ -348,10 +348,18 @@ class AdaptiveCardBuilder:
             AdaptiveCardBuilder: Builder object
         """
         if width == types.MSTeamsCardWidth.FULL:
-            self.__card.msteams = types.MSTeams(width=width)
+            if self.__card.msteams is None:
+                self.__card.msteams = types.MSTeams()
+            self.__card.msteams.width = width
             return self
 
         self.__card.msteams = None
+        return self
+
+    def mentions(self, users: list[types.MentionUser]) -> "AdaptiveCardBuilder":
+        if self.__card.msteams is None:
+            self.__card.msteams = types.MSTeams()
+        self.__card.msteams.entities = [user for user in users]
         return self
 
     def add_item(self, item: ElementAnnotated) -> "AdaptiveCardBuilder":

--- a/src/adaptive_cards/types.py
+++ b/src/adaptive_cards/types.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
+import html
+from typing import Optional, Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
 from pydantic.alias_generators import to_camel
 
 from adaptive_cards import utils
@@ -465,6 +466,30 @@ class Metadata(TypeBaseModel):
     )
 
 
+class MentionUser(TypeBaseModel):
+    """Mentionable user."""
+
+    id: str  # user email address
+    name: str  # display text
+
+    @model_serializer(mode='plain')
+    def serialize(self) -> dict[str, Any]:
+        """Generates a mentionable entity."""
+        escaped_id = html.escape(self.id)
+        escaped_name = html.escape(self.name)
+        return {
+            "type": "mention",
+            "text": f"<at>{escaped_name}</at>",
+            "mentioned": {"id": escaped_id, "name": escaped_name},
+        }
+
+    @property
+    def mention(self) -> str:
+        """Generates an @Mention string."""
+        escaped_name = html.escape(self.name)
+        return f"<at>{escaped_name}</at>"
+
+
 class MSTeams(TypeBaseModel):
     """
     Represents specific properties for MS Teams as the target framework.
@@ -474,6 +499,10 @@ class MSTeams(TypeBaseModel):
                when posted to MS Teams. Defaults to "None".
     """
 
+    entities: Optional[list[MentionUser]] = Field(
+        default=None, json_schema_extra=utils.get_metadata("1.2")
+    )
+
     width: Optional[MSTeamsCardWidth] = Field(
-        default=MSTeamsCardWidth.DEFAULT, json_schema_extra=utils.get_metadata("1.0")
+        default=None, json_schema_extra=utils.get_metadata("1.0")
     )

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -2,6 +2,7 @@ import pytest
 from result import is_err, is_ok
 
 from adaptive_cards.card import ActionSubmit, AdaptiveCard, InputText, TextBlock
+import adaptive_cards.types as types
 
 
 class TestAdaptiveCard:
@@ -245,3 +246,12 @@ class TestAdaptiveCard:
         card = AdaptiveCard.new().add_action(action_submit).version("1.3").create()
         result = card.update_action("action1", title=123)
         assert is_err(result)
+
+    def test_add_mention(self):
+        """Test adding a mention to a card."""
+        users = [types.MentionUser(id="user@example.com", name="User")]
+        card = AdaptiveCard.new().version("1.2").mentions(users).create()
+        assert isinstance(card.msteams, types.MSTeams)
+        assert isinstance(card.msteams.entities, list)
+        assert len(card.msteams.entities) == 1
+        assert card.msteams.entities == users


### PR DESCRIPTION
# 📖 Description

This PR adds support for mentioning users in MS Teams adaptive cards. The main changes introduce a new `MentionUser` type, update the `MSTeams` model to support the `entities` attribute, and provide a builder method to add mentions to a card. Tests are also added to ensure mentions work as expected.

### MS Teams @mentions support:

- Added a `MentionUser` model in `types.py` to represent mentionable users, including serialization logic for MS Teams' mention entity format.
- Updated the `MSTeams` model to include an optional `entities` field for mentions and changed the default for `width` to `None` so that it doesn't get created if it doesn't have a value (and the _mention_ not to work).

### Adaptive card builder enhancements:

- Added a `mentions` method to `AdaptiveCardBuilder` in `card.py` to allow attaching a list of `MentionUser` objects to a card, ensuring the `MSTeams` object is initialized if needed.

## 🧪 Testing:

- Added a test case to verify that mentions can be added to a card and are properly reflected in the resulting `MSTeams` object.

## ⚙️ Usage:

```python
users = [
    MentionUser(id="user1@example.com", name="User1"),
    MentionUser(id="user2@example.com", name="User2"),
]
text_block = TextBlock(text=f"🔔 {' ,'.join(user.mention for user in users)}")
card = AdaptiveCard.new().add_item(text_block).mentions(users).create()
TeamsClient(hook_url).send(card)
```
