### PR TITLE
move mypy to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Further resources can be found here:
 * `pydantic`
 * `requests`
 * `jsonschema`
-* `mypy`
 * `result`
 
 Works with Python 3.10+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "requests",
     "jsonschema",
     "pydantic>=2.10.6",
-    "mypy>=1.15.0",
     "result>=0.17.0",
 ]
 requires-python = ">=3.10"
@@ -33,6 +32,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "mypy>=1.15.0",
     "pytest>=8.3.5",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,6 @@ version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },
-    { name = "mypy" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "result" },
@@ -16,20 +15,23 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "jsonschema" },
-    { name = "mypy", specifier = ">=1.15.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "requests" },
     { name = "result", specifier = ">=0.17.0" },
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.5" }]
+dev = [
+    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+]
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
mypy (and other static analysis tools) should only be listed as dev dependencies because they aren't necessary for downstream users.

in my case, i'm using a different type checker (basedpyright) so i shouldn't need to have mypy installed at all