### PR TITLE
Delete legacy build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#! /usr/bin/bash
-
-python3.10 -m build
-python3 -m twine upload -r pypi dist/*
-
-rm -r adaptive_cards_py.egg* dist


### PR DESCRIPTION
## Description

This script has been initially used for manual publishing. Since there are proper GH Action Workflows in place, the file is no longer needed. 